### PR TITLE
provides go-jsonnet native functions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,19 +5,19 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.20"
           - "1.21"
+          - "1.22"
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build & Test
         run: |

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.5 // indirect
 	github.com/aws/smithy-go v1.14.2 // indirect
+	github.com/google/go-jsonnet v0.20.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33uT4g=
+github.com/google/go-jsonnet v0.20.0/go.mod h1:VbgWF9JX7ztlv770x/TolZNGGFfiHEVx9G6ca2eUmeA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -45,3 +47,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
+sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/ssm/funcs.go
+++ b/ssm/funcs.go
@@ -12,7 +12,10 @@ import (
 func FuncMap(ctx context.Context, cfg aws.Config) (template.FuncMap, error) {
 	cache := sync.Map{}
 	app := New(cfg, &cache)
+	return app.FuncMap(ctx), nil
+}
 
+func (app *App) FuncMap(ctx context.Context) template.FuncMap {
 	return template.FuncMap{
 		"ssm": func(paramName string, index ...int) (string, error) {
 			value, err := app.Lookup(ctx, paramName, index...)
@@ -21,5 +24,5 @@ func FuncMap(ctx context.Context, cfg aws.Config) (template.FuncMap, error) {
 			}
 			return value, nil
 		},
-	}, nil
+	}
 }

--- a/ssm/jsonnet.go
+++ b/ssm/jsonnet.go
@@ -1,0 +1,48 @@
+package ssm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/ast"
+)
+
+func JsonnetNativeFuncs(ctx context.Context, cfg aws.Config) ([]*jsonnet.NativeFunction, error) {
+	cache := sync.Map{}
+	app := New(cfg, &cache)
+	return app.JsonnetNativeFuncs(ctx), nil
+}
+
+func (app *App) JsonnetNativeFuncs(ctx context.Context) []*jsonnet.NativeFunction {
+	return []*jsonnet.NativeFunction{
+		{
+			Name: "ssm",
+			Func: func(p []interface{}) (interface{}, error) {
+				paramName, ok := p[0].(string)
+				if !ok {
+					return nil, fmt.Errorf("ssm: parameter name must be a string")
+				}
+				return app.Lookup(ctx, paramName)
+			},
+			Params: []ast.Identifier{"name"},
+		},
+		{
+			Name: "ssm_list",
+			Func: func(p []interface{}) (interface{}, error) {
+				paramName, ok := p[0].(string)
+				if !ok {
+					return nil, fmt.Errorf("ssm: parameter name must be a string")
+				}
+				index, ok := p[1].(float64)
+				if !ok {
+					return nil, fmt.Errorf("ssm: index must be a number")
+				}
+				return app.Lookup(ctx, paramName, int(index))
+			},
+			Params: []ast.Identifier{"name", "index"},
+		},
+	}
+}

--- a/ssm/jsonnet_test.go
+++ b/ssm/jsonnet_test.go
@@ -1,0 +1,52 @@
+package ssm_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-jsonnet"
+)
+
+func TestJsonnetNativeFunc(t *testing.T) {
+	ctx := context.Background()
+	app := newMockApp(mockGetParameter)
+
+	funcs := app.JsonnetNativeFuncs(ctx)
+	vm := jsonnet.MakeVM()
+	for _, fn := range funcs {
+		vm.NativeFunction(fn)
+	}
+	out, err := vm.EvaluateAnonymousSnippet("test.jsonnet", `
+	local ssm = std.native("ssm");
+	local ssm_list = std.native("ssm_list");
+	{
+		"string": ssm("/string"),
+		"stringlist": [ssm_list("/stringlist", 0), ssm_list("/stringlist", 1)],
+		"securestring": ssm("/securestring")
+	}`+"\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ob := new(bytes.Buffer)
+	if err := json.Indent(ob, []byte(out), "", "  "); err != nil {
+		t.Fatal(err)
+	}
+	eb := new(bytes.Buffer)
+	expect := `{
+      "securestring": "securestring value",
+      "string": "string value",
+      "stringlist": [
+        "stringlist value 1",
+        "stringlist value 2"
+      ]
+    }` + "\n"
+	if err := json.Indent(eb, []byte(expect), "", "  "); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(ob.String(), eb.String()); diff != "" {
+		t.Errorf("unexpected output: %s", diff)
+	}
+}


### PR DESCRIPTION
This PR adds `JsonnetNativeFuncs()` returns go-jsonnet native functions.

```go
vm := jsonnet.MakeVM()
funcs := ssm.JsonnetNativeFuncs(ctx, awsCfg)
for _, fn := range funcs {
	vm.NativeFunction(fn)
}
```

```jsonnet
local ssm = std.native("ssm");
local ssm_list = std.native("ssm_list");
{
	"string": ssm("/string"),
	"stringlist": [ssm_list("/stringlist", 0), ssm_list("/stringlist", 1)],
	"securestring": ssm("/securestring")
}
```